### PR TITLE
Cleaning up formatting to improve diff readability

### DIFF
--- a/Mission Files/hardcore.namalsk/cfgspawnabletypes.xml
+++ b/Mission Files/hardcore.namalsk/cfgspawnabletypes.xml
@@ -1963,7 +1963,30 @@
         <cargo preset="Gifts_MedMags" />
         <cargo preset="Gifts_BigModules" />
     </type>
-    
+
+
+    <!-- NAMALSK - VEHICLES -->
+    <type name="Boat_01_Black">
+        <attachments chance="0.30">
+            <item name="SparkPlug" chance="1.00" />
+        </attachments>
+    </type>
+    <type name="Boat_01_Blue">
+        <attachments chance="0.30">
+            <item name="SparkPlug" chance="1.00" />
+        </attachments>
+    </type>
+    <type name="Boat_01_Camo">
+        <attachments chance="0.30">
+            <item name="SparkPlug" chance="1.00" />
+        </attachments>
+    </type>
+    <type name="Boat_01_Orange">
+        <attachments chance="0.30">
+            <item name="SparkPlug" chance="1.00" />
+        </attachments>
+    </type>
+
 
     <!-- NAMALSK - INFECTED -->
     <type name="ZmbF_BlueCollarFat_Blue">
@@ -2504,28 +2527,6 @@
     <type name="ZmbM_Santa">
         <attachments chance="1.00">
             <item name="SantasHat" chance="1.00" />
-        </attachments>
-    </type>
-
-    <!-- NAMALSK - VEHICLES -->
-    <type name="Boat_01_Black">
-        <attachments chance="0.30">
-            <item name="SparkPlug" chance="1.00" />
-        </attachments>
-    </type>
-    <type name="Boat_01_Blue">
-        <attachments chance="0.30">
-            <item name="SparkPlug" chance="1.00" />
-        </attachments>
-    </type>
-    <type name="Boat_01_Camo">
-        <attachments chance="0.30">
-            <item name="SparkPlug" chance="1.00" />
-        </attachments>
-    </type>
-    <type name="Boat_01_Orange">
-        <attachments chance="0.30">
-            <item name="SparkPlug" chance="1.00" />
         </attachments>
     </type>
 </spawnabletypes>

--- a/Mission Files/hardcore.namalsk/db/types.xml
+++ b/Mission Files/hardcore.namalsk/db/types.xml
@@ -9578,7 +9578,7 @@
     <category name="bags" />
     <tag name="military" />
   </type>
-  
+
 
   <!-- 80+ SLOTS -->
   <type name="MountainBag_Blue">
@@ -15936,35 +15936,7 @@
   </type>
 
 
-  <!-- GENERAL VEHICLE PARTS -->
-  <type name="SparkPlug">
-    <nominal>12</nominal>
-    <min>10</min>
-    <lifetime>2700</lifetime>
-    <restock>0</restock>
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
-    <category name="tools" />
-    <tag name="civilian" />
-    <tag name="industrial" />
-  </type>
-  <type name="CanisterGasoline">
-    <nominal>25</nominal>
-    <min>22</min>
-    <lifetime>5400</lifetime>
-    <restock>0</restock>
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
-    <category name="tools" />
-    <tag name="civilian" />
-    <tag name="industrial" />
-  </type>
-
-  <!-- DE support - vehicles -->
+  <!-- DE support - vehicles and parts -->
   <type name="Boat_01_Black">
     <nominal>0</nominal>
     <min>0</min>
@@ -16004,5 +15976,34 @@
     <quantmax>-1</quantmax>
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
+  </type>
+
+
+  <!-- GENERAL VEHICLE PARTS -->
+  <type name="CanisterGasoline">
+    <nominal>25</nominal>
+    <min>22</min>
+    <lifetime>5400</lifetime>
+    <restock>0</restock>
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
+    <category name="tools" />
+    <tag name="civilian" />
+    <tag name="industrial" />
+  </type>
+  <type name="SparkPlug">
+    <nominal>12</nominal>
+    <min>10</min>
+    <lifetime>2700</lifetime>
+    <restock>0</restock>
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
+    <category name="tools" />
+    <tag name="civilian" />
+    <tag name="industrial" />
   </type>
 </types>

--- a/Mission Files/regular.namalsk/cfgspawnabletypes.xml
+++ b/Mission Files/regular.namalsk/cfgspawnabletypes.xml
@@ -538,6 +538,7 @@
         </attachments>
     </type>
 
+
     <!-- NAMALSK - WEAPONS - EXPLOSIVES -->
     <!-- none require special care -->
 

--- a/Mission Files/regular.namalsk/db/types.xml
+++ b/Mission Files/regular.namalsk/db/types.xml
@@ -3420,7 +3420,7 @@
     <tag name="seaice" />
   </type>
 
-  
+
   <!-- NAMALSK - FOOD N DRINKS -->
   <type name="BoxCerealCrunchin">
     <nominal>4</nominal>
@@ -4149,6 +4149,7 @@
     <category name="tools" />
     <tag name="medical" />
   </type>
+
 
   <!-- NAMALSK - MISC ITEMS -->
   <type name="GasMask_Filter">
@@ -5448,21 +5449,6 @@
     <tag name="civilian" />
     <tag name="hunting" />
   </type>
-  <type name="TireRepairKit">
-    <nominal>20</nominal>
-    <min>17</min>
-    <lifetime>2700</lifetime>
-    <restock>0</restock>
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_map="1" count_in_hoarder="0" count_in_cargo="0" count_in_player="0" crafted="0" deloot="0" />
-    <usage />
-    <value />
-    <category name="tools" />
-    <tag name="civilian" />
-    <tag name="industrial" />
-  </type>
   <type name="Whetstone">
     <nominal>20</nominal>
     <min>15</min>
@@ -5478,6 +5464,21 @@
     <tag name="civilian" />
     <tag name="industrial" />
     <tag name="hunting" />
+  </type>
+  <type name="TireRepairKit">
+    <nominal>20</nominal>
+    <min>17</min>
+    <lifetime>2700</lifetime>
+    <restock>0</restock>
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_map="1" count_in_hoarder="0" count_in_cargo="0" count_in_player="0" crafted="0" deloot="0" />
+    <usage />
+    <value />
+    <category name="tools" />
+    <tag name="civilian" />
+    <tag name="industrial" />
   </type>
   <type name="ElectronicRepairKit">
     <nominal>12</nominal>
@@ -13990,11 +13991,11 @@
     <lifetime>2700</lifetime>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="1" deloot="0" /> 
   </type>
-  <type name="RemoteDetonatorTrigger">
+  <type name="ImprovisedExplosive">
     <lifetime>3600</lifetime>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="1" deloot="0" /> 
   </type>
-  <type name="ImprovisedExplosive">
+  <type name="RemoteDetonatorTrigger">
     <lifetime>3600</lifetime>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="1" deloot="0" /> 
   </type>
@@ -16517,6 +16518,7 @@
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
   </type>
+
   <!-- ADA -->
   <type name="OffroadHatchback">
     <nominal>0</nominal>
@@ -17109,23 +17111,6 @@
     <tag name="civilian" />
     <tag name="industrial" />
   </type>
-  <type name="HeadlightH7_Box">
-    <nominal>25</nominal>
-    <min>22</min>
-    <lifetime>2700</lifetime>
-    <restock>0</restock>
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
-    <category name="tools" />
-    <tag name="civilian" />
-    <tag name="industrial" />
-  </type>
-  <type name="HeadlightH7">
-    <lifetime>1800</lifetime>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="1" deloot="0"/>
-  </type>
   <type name="SparkPlug">
     <nominal>25</nominal>
     <min>22</min>
@@ -17151,6 +17136,23 @@
     <category name="tools" />
     <tag name="military" />
     <tag name="industrial" />
+  </type>
+  <type name="HeadlightH7_Box">
+    <nominal>25</nominal>
+    <min>22</min>
+    <lifetime>2700</lifetime>
+    <restock>0</restock>
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0"/>
+    <category name="tools" />
+    <tag name="civilian" />
+    <tag name="industrial" />
+  </type>
+  <type name="HeadlightH7">
+    <lifetime>1800</lifetime>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="1" deloot="0"/>
   </type>
   <type name="CarRadiator">
     <nominal>12</nominal>

--- a/Mission Files/regular.namalsk/db/types.xml
+++ b/Mission Files/regular.namalsk/db/types.xml
@@ -5852,7 +5852,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5865,7 +5864,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5878,7 +5876,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5891,7 +5888,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5904,7 +5900,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5917,7 +5912,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5930,7 +5924,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5943,7 +5936,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5956,7 +5948,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5969,7 +5960,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5982,7 +5972,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -5995,7 +5984,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -6008,7 +5996,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -6021,7 +6008,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -6034,7 +6020,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -6047,7 +6032,6 @@
     <min>1</min>
     <lifetime>2700</lifetime>
     <restock>0</restock>
-    <min>0</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>


### PR DESCRIPTION
db\types.xml:
- Reduced diff count by ~10.
- Removed `<min>0</min>` from all Flag_* objects (defined twice)
    
cfgspawnabletypes.xml:
- Hardcore had boats at end of list, moved higher to match regular mission for diff readability.

Notes:
- I noticed `NBCBootsWhite` is missing from the `normal` mission, but wasn't clear why that would be.
- I suppose the `Flag_* <min>` values should be either 0 or 1, not sure the intent but I removed the second references as they were uniquely ordered compared to other types and it _seems_ like it should be 1.
- Tested both missions on my test server for basic "loadability"; they seem to work fine.